### PR TITLE
fix: do not use spread operator on valid dates

### DIFF
--- a/projects/ngneat/forms-manager/src/lib/forms-manager.spec.ts
+++ b/projects/ngneat/forms-manager/src/lib/forms-manager.spec.ts
@@ -9,7 +9,11 @@ function getSnapshot(formsManager) {
 }
 
 describe('FormsManager', () => {
-  let formsManager: NgFormsManager, control: FormControl, arr: FormArray, group: FormGroup;
+  let formsManager: NgFormsManager,
+    control: FormControl,
+    arr: FormArray,
+    group: FormGroup,
+    date: Date;
 
   beforeEach(() => {
     formsManager = new NgFormsManager(new NgFormsManagerConfig());
@@ -18,12 +22,14 @@ describe('FormsManager', () => {
     group = new FormGroup({
       name: new FormControl(),
       email: new FormControl(),
+      date: new FormControl(),
       phone: new FormGroup({
         number: new FormControl(),
         prefix: new FormControl(),
       }),
       arr: new FormArray([]),
     });
+    date = new Date();
 
     formsManager
       .upsert('config', control)
@@ -67,6 +73,7 @@ describe('FormsManager', () => {
         value: {
           name: null,
           email: null,
+          date: null,
           phone: {
             number: null,
             prefix: null,
@@ -76,6 +83,7 @@ describe('FormsManager', () => {
         rawValue: {
           name: null,
           email: null,
+          date: null,
           phone: {
             number: null,
             prefix: null,
@@ -104,6 +112,18 @@ describe('FormsManager', () => {
             pending: false,
           },
           email: {
+            value: null,
+            rawValue: null,
+            valid: true,
+            dirty: false,
+            invalid: false,
+            disabled: false,
+            errors: null,
+            touched: false,
+            pristine: true,
+            pending: false,
+          },
+          date: {
             value: null,
             rawValue: null,
             valid: true,
@@ -207,6 +227,7 @@ describe('FormsManager', () => {
         value: {
           name: null,
           email: null,
+          date: null,
           phone: {
             number: null,
             prefix: null,
@@ -216,6 +237,7 @@ describe('FormsManager', () => {
         rawValue: {
           name: null,
           email: null,
+          date: null,
           phone: {
             number: null,
             prefix: null,
@@ -244,6 +266,18 @@ describe('FormsManager', () => {
             pending: false,
           },
           email: {
+            value: null,
+            rawValue: null,
+            valid: true,
+            dirty: false,
+            invalid: false,
+            disabled: false,
+            errors: null,
+            touched: false,
+            pristine: true,
+            pending: false,
+          },
+          date: {
             value: null,
             rawValue: null,
             valid: true,
@@ -373,6 +407,7 @@ describe('FormsManager', () => {
         value: {
           name: null,
           email: null,
+          date: null,
           phone: {
             number: null,
             prefix: null,
@@ -382,6 +417,7 @@ describe('FormsManager', () => {
         rawValue: {
           name: null,
           email: null,
+          date: null,
           phone: {
             number: null,
             prefix: null,
@@ -410,6 +446,18 @@ describe('FormsManager', () => {
             pending: false,
           },
           email: {
+            value: null,
+            rawValue: null,
+            valid: true,
+            dirty: false,
+            invalid: false,
+            disabled: false,
+            errors: null,
+            touched: false,
+            pristine: true,
+            pending: false,
+          },
+          date: {
             value: null,
             rawValue: null,
             valid: true,
@@ -484,6 +532,7 @@ describe('FormsManager', () => {
     group.patchValue({
       name: 'Netanel',
       email: 'n@n.com',
+      date: date,
       phone: {
         number: 1,
         prefix: 2,
@@ -547,6 +596,7 @@ describe('FormsManager', () => {
         value: {
           name: 'Netanel',
           email: 'n@n.com',
+          date: date,
           phone: {
             number: 1,
             prefix: 2,
@@ -556,6 +606,7 @@ describe('FormsManager', () => {
         rawValue: {
           name: 'Netanel',
           email: 'n@n.com',
+          date: date,
           phone: {
             number: 1,
             prefix: 2,
@@ -585,6 +636,18 @@ describe('FormsManager', () => {
           },
           email: {
             value: 'n@n.com',
+            rawValue: null,
+            valid: true,
+            dirty: false,
+            invalid: false,
+            disabled: false,
+            errors: null,
+            touched: false,
+            pristine: true,
+            pending: false,
+          },
+          date: {
+            value: date,
             rawValue: null,
             valid: true,
             dirty: false,
@@ -756,6 +819,7 @@ describe('FormsManager', () => {
       value: {
         name: null,
         email: null,
+        date: null,
         phone: {
           number: null,
           prefix: null,
@@ -765,6 +829,7 @@ describe('FormsManager', () => {
       rawValue: {
         name: null,
         email: null,
+        date: null,
         phone: {
           number: null,
           prefix: null,
@@ -793,6 +858,18 @@ describe('FormsManager', () => {
           pending: false,
         },
         email: {
+          value: null,
+          rawValue: null,
+          valid: true,
+          dirty: false,
+          invalid: false,
+          disabled: false,
+          errors: null,
+          touched: false,
+          pristine: true,
+          pending: false,
+        },
+        date: {
           value: null,
           rawValue: null,
           valid: true,
@@ -875,6 +952,7 @@ describe('FormsManager', () => {
       value: {
         name: null,
         email: null,
+        date: null,
         phone: {
           number: 3,
           prefix: 4,
@@ -884,6 +962,7 @@ describe('FormsManager', () => {
       rawValue: {
         name: null,
         email: null,
+        date: null,
         phone: {
           number: 3,
           prefix: 4,
@@ -912,6 +991,18 @@ describe('FormsManager', () => {
           pending: false,
         },
         email: {
+          value: null,
+          rawValue: null,
+          valid: true,
+          dirty: false,
+          invalid: false,
+          disabled: false,
+          errors: null,
+          touched: false,
+          pristine: true,
+          pending: false,
+        },
+        date: {
           value: null,
           rawValue: null,
           valid: true,

--- a/projects/ngneat/forms-manager/src/lib/utils.ts
+++ b/projects/ngneat/forms-manager/src/lib/utils.ts
@@ -25,8 +25,12 @@ export function clone(value: any): any {
   return isObject(value) ? { ...value } : Array.isArray(value) ? [...value] : value;
 }
 
+export function isValidDate(value: any): boolean {
+  return value && Object.prototype.toString.call(value) === '[object Date]' && !isNaN(value);
+}
+
 export function isObject(val) {
-  if (val == null || Array.isArray(val)) {
+  if (val == null || Array.isArray(val) || isValidDate(val)) {
     return false;
   }
 


### PR DESCRIPTION
To ensure that isObject does not return true for dates to avoid using the spread operator on a date causing it to be an empty object.

PR Close #7

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngneat/forms-manager/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

(https://github.com/ngneat/forms-manager/issues/7)

Issue Number:7

## What is the new behavior?

A date value is not cloned using the spread operator leaving it as an empty object.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
