### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const nameDisabled$ = formsManager.disableChanges('onboarding', 'name');
 
 ```ts
 const errors$ = formsManager.errorsChanges<Errors>('onboarding');
-const nameErros$ = formsManager.errorsChanges<Errors>('onboarding', 'name');
+const nameErrors$ = formsManager.errorsChanges<Errors>('onboarding', 'name');
 ```
 
 - `controlChanges()` - Observe the control's state


### PR DESCRIPTION
Hey,

This tiny PR will fix : 

- 1 typo in `README.md`



Bye! :robot: