### PR TITLE
Added proxy method `reset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ formsManager.patchValue('onboarding', value, options);
 formsManager.setValue('onboarding', value, options);
 ```
 
+- `reset()` - A proxy to the original `reset` method
+
+```ts
+formsManager.reset('onboarding', value, options);
+```
+
 - `markAllAsTouched()` - A proxy to the original `markAllAsTouched` method
 
 ```ts

--- a/projects/ngneat/forms-manager/src/lib/forms-manager.ts
+++ b/projects/ngneat/forms-manager/src/lib/forms-manager.ts
@@ -1,13 +1,13 @@
 import { Inject, Injectable, Optional } from '@angular/core';
-import { AbstractControl, FormGroup, FormArray } from '@angular/forms';
-import { coerceArray, filterControlKeys, filterNil, isBrowser, mergeDeep } from './utils';
+import { AbstractControl, FormArray, FormGroup } from '@angular/forms';
 import { EMPTY, merge, Observable, Subject, Subscription, timer } from 'rxjs';
-import { debounce, distinctUntilChanged, filter, map, mapTo, tap } from 'rxjs/operators';
-import { FormsStore } from './forms-manager.store';
-import { Control, ControlFactory, FormKeys, HashMap, UpsertConfig } from './types';
-import { Config, NG_FORMS_MANAGER_CONFIG, NgFormsManagerConfig } from './config';
-import { isEqual } from './isEqual';
+import { debounce, distinctUntilChanged, filter, map, mapTo } from 'rxjs/operators';
 import { deleteControl, findControl, handleFormArray, toStore } from './builders';
+import { Config, NgFormsManagerConfig, NG_FORMS_MANAGER_CONFIG } from './config';
+import { FormsStore } from './forms-manager.store';
+import { isEqual } from './isEqual';
+import { Control, ControlFactory, FormKeys, HashMap, UpsertConfig } from './types';
+import { coerceArray, filterControlKeys, filterNil, isBrowser, mergeDeep } from './utils';
 
 const NO_DEBOUNCE = Symbol('NO_DEBOUNCE');
 
@@ -263,6 +263,28 @@ export class NgFormsManager<FormsState = any> {
   ) {
     if (this.instances$$.has(name)) {
       this.instances$$.get(name).setValue(value, options);
+    }
+  }
+
+  /**
+   *
+   * @example
+   *
+   * A proxy to the original `reset` method
+   *
+   * manager.reset('login', { email: '' });
+   *
+   */
+  reset<T extends keyof FormsState>(
+    name: T,
+    value?: Partial<FormsState[T]>,
+    options?: {
+      onlySelf?: boolean;
+      emitEvent?: boolean;
+    }
+  ) {
+    if (this.instances$$.has(name)) {
+      this.instances$$.get(name).reset(value, options);
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/forms-manager/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There was no proxy for the `reset` method of an `AbstractControl` (like for `patchValue` and `setValue`).

## What is the new behavior?

I added one

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I would have added a unit test for `reset`, if there would have been one for `setValue` (most likely only copy/paste), but I wasn't able to identify one :/
