### PR TITLE
fix: 🐛 clear all initial values when clearing complete store

### DIFF
--- a/projects/ngneat/forms-manager/src/lib/forms-manager.spec.ts
+++ b/projects/ngneat/forms-manager/src/lib/forms-manager.spec.ts
@@ -1273,6 +1273,11 @@ describe('FormsManager', () => {
       }),
     });
 
+    const addressForm = new FormGroup({
+      zip: new FormControl('12345'),
+      place: new FormControl('Schenectady'),
+    });
+
     it('should get and set initial Value for a control', () => {
       formsManager.setInitialValue('config', 'initial');
 
@@ -1305,6 +1310,26 @@ describe('FormsManager', () => {
 
     it('should get undefined if no initial Value set', () => {
       expect(formsManager.getInitialValue('other')).toBeUndefined();
+    });
+
+    it('should clear initial Value for a group of control', () => {
+      formsManager.upsert('user', userForm, { withInitialValue: true });
+      formsManager.upsert('address', addressForm, { withInitialValue: true });
+
+      formsManager.clear('user');
+
+      expect(formsManager.getInitialValue('user')).toBeUndefined();
+      expect(formsManager.getInitialValue('address')).toBeDefined();
+    });
+
+    it('should clear all initial Values when clearing full store', () => {
+      formsManager.upsert('user', userForm, { withInitialValue: true });
+      formsManager.upsert('address', addressForm, { withInitialValue: true });
+
+      formsManager.clear();
+
+      expect(formsManager.getInitialValue('user')).toBeUndefined();
+      expect(formsManager.getInitialValue('address')).toBeUndefined();
     });
   });
 

--- a/projects/ngneat/forms-manager/src/lib/forms-manager.ts
+++ b/projects/ngneat/forms-manager/src/lib/forms-manager.ts
@@ -638,8 +638,10 @@ export class NgFormsManager<FormsState = any> {
     return value;
   }
 
-  private removeInitialValue(name: FormKeys<FormsState>) {
-    coerceArray(name).forEach(name => this.initialValues$$.delete(name));
+  private removeInitialValue(name?: FormKeys<FormsState>) {
+    name
+      ? coerceArray(name).forEach(name => this.initialValues$$.delete(name))
+      : this.initialValues$$.clear();
   }
 
   private markDescendantsAsDirty(


### PR DESCRIPTION
Clears complete Map of initial values when the store is getting cleared.

Closes: #29

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/forms-manager/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When calling the methods formsManager.clear() or formsManager.destroy() without parameters the existing initial values are not being cleared.

Issue Number: #29 

## What is the new behavior?

All initial values are now being cleared when clearing the complete store.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
